### PR TITLE
Add autoFocus attribute to form to render pages without autofocus

### DIFF
--- a/src/components/CommentForm/CommentForm.js
+++ b/src/components/CommentForm/CommentForm.js
@@ -59,6 +59,7 @@ class CommentForm extends Component {
             data-cy='user_name'
             value={this.state.user_name}
             onChange={(event) => this.handleChange(event)}
+            autoFocus=''
             required
           />
           <textarea 
@@ -68,6 +69,7 @@ class CommentForm extends Component {
             data-cy='user_message'
             value={this.state.user_message}
             onChange={(event) => this.handleChange(event)}
+            autoFocus=''
             required
           />
           <button 


### PR DESCRIPTION
# Description
Add auto focus attribute so tea pages do not auto scroll to form when clicked

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactor

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] I tested my changes in the browser
- [ ] I tested with Mocha/Chai
- [ ] I tested with Cypress

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new bugs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Is your code D.R.Y?
- [ ] Does it follow SRP?
