### PR TITLE
Fix page content jumping after route change

### DIFF
--- a/src/components/ScrollToTop/index.js
+++ b/src/components/ScrollToTop/index.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { withRouter } from "react-router-dom";
+
+class ScrollToTop extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.location.pathname !== prevProps.location.pathname
+    ) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default withRouter(ScrollToTop);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,12 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom'
 import './index.css';
 import App from '../src/components/App/App';
+import ScrollToTop from '../src/components/ScrollToTop'
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<BrowserRouter> <App /> </BrowserRouter>);
+root.render(
+  <BrowserRouter> 
+    <ScrollToTop/>
+    <App />
+  </BrowserRouter>);
 


### PR DESCRIPTION
# Description

When click on a tea card, the content of the teaPage is off positioned. Instead of displaying from the top of the page, it would be some times in the middle, some times in the bottom. Yet it display content correctly if user refresh the page.

The [scroll restoration](https://v5.reactrouter.com/web/guides/scroll-restoration) (read more about "scroll to the top”) was provided by React Router in versions before 5. This means if you click on a button that takes you to a different page, React Router would automatically scroll to the top for you on the new page.
Since new version released, this is no longer automatically included. We are using React Router 5, hence the fix.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactor

# How Has This Been Tested?

run app, click on different tea card from home page, and the content should be displayed as expected.

- [x] I tested my changes in the browser
- [ ] I tested with Mocha/Chai
- [ ] I tested with Cypress

# Screenshot

https://user-images.githubusercontent.com/68085997/202342989-eb30a805-57ea-4827-a326-9a4a85b5c2ae.mov

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new bugs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Is your code D.R.Y?
- [ ] Does it follow SRP?
